### PR TITLE
Correct null value manual quote

### DIFF
--- a/src/Miner.php
+++ b/src/Miner.php
@@ -381,7 +381,10 @@
         return $PdoConnection->quote($value);
       }
       elseif (is_numeric($value)) {
-        return $value;
+        return $value;        
+      }
+      elseif (is_null($value)) {
+        return "NULL";
       }
       else {
         return "'" . addslashes($value) . "'";


### PR DESCRIPTION
Miner converts null values to empty string when does manual quote. I want him to keep null. Thanks.
